### PR TITLE
Fix live lock looping

### DIFF
--- a/pyeiscp/protocol.py
+++ b/pyeiscp/protocol.py
@@ -376,7 +376,7 @@ class AVR(asyncio.Protocol):
                     if self._update_callback:
                         self._loop.call_soon(self._update_callback, message)
                 except:
-                    self.log.warning("Unable to parse recieved message: %s", data.decode().rstrip())
+                    self.log.warning("Unable to parse recieved message: %s", data.decode('utf-8', 'backslashreplace').rstrip())
 
                 self.buffer = self.buffer[16 + size :]  # shift data to start
                 # If there is still data in the buffer,


### PR DESCRIPTION
If a non utf-8 character is received then in the except: block we try to decode it which causes an error. This means the buffer isn't moved on and the lib gets stuck in a tight loop constantly trying the same character over again.

Add an error handler so the decode will print a useful string e.g.:

```
2020-10-20 10:34:23 WARNING (MainThread) [pyeiscp.protocol] Unable to parse recieved message: !1UPD\xcd
```