### PR TITLE
Fixed a bug that broke the reconnect loop and changed the disconnect callback

### DIFF
--- a/pyeiscp/connection.py
+++ b/pyeiscp/connection.py
@@ -151,7 +151,7 @@ class Connection:
         conn._closing = False
         conn._halted = False
         conn._auto_reconnect = auto_reconnect
-        conn.max_retry_interval = max_retry_interval
+        conn._max_retry_interval = max_retry_interval
 
         def _disconnect_callback():
             """Function callback for Protocol class when connection is lost."""

--- a/pyeiscp/tools.py
+++ b/pyeiscp/tools.py
@@ -37,11 +37,12 @@ async def console(loop, log):
 
     logging.basicConfig(level=level)
 
-    def log_callback(message):
+    def log_callback(message, host):
         """Receives event callback from eISCP Protocol class."""
         zone, command, value = message
         log.info("Zone: %s | %s: %s" % (zone, command, value))
-    def connect_callback():
+
+    def connect_callback(host):
         log.info("Successfully (re)connected to AVR")
 
     host = args.host

--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,7 @@ def readme():
 
 setup(
     name="pyeiscp",
-    version="0.0.6",
+    version="0.0.7",
     author="Mathieu Pasquet",
     author_email="mat@pyeiscp.pasquet.co",
     url="https://github.com/winterscar/python-eiscp",


### PR DESCRIPTION
Too bad, I just noticed I pushed my previous PR too quickly, so I missed a bug.
@winterscar Could you maybe also merge this PR to fix it?

Edit: I also moved the call to the disconnect callback to after the first retry when auto reconnect is enabled, since I saw that the connection is reset every now and then.