### PR TITLE
Replace Invalid utf-8 Characters 

### DIFF
--- a/pyeiscp/protocol.py
+++ b/pyeiscp/protocol.py
@@ -85,7 +85,7 @@ class eISCPPacket(object):
         """Parse the eISCP package given by ``bytes``.
         """
         h = cls.parse_header(bytes[:16])
-        data = bytes[h.header_size : h.header_size + h.data_size].decode()
+        data = bytes[h.header_size : h.header_size + h.data_size].decode(errors='replace')
         assert len(data) == h.data_size
         return data
 


### PR DESCRIPTION
I have a stereo system that returns this from the discovery process
`b'!1ECNDRX-3.3/60128/DX/0009B0F35470\xff\xff\x19\r\n'`

After the identifier in this string of bytes there is the `\xff` character, which causes the decode method to fail. Setting `decode`'s error handling to replace instead of strict allows me to work around this.

The model is an Integra DRX 3.3